### PR TITLE
Add visual 3d control for manipulating rotations

### DIFF
--- a/FFTrainer/Converters/QuaternionConverter.cs
+++ b/FFTrainer/Converters/QuaternionConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media.Media3D;
+
+namespace FFTrainer.Converters
+{
+    public class QuaternionConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if ((values.Length < 4) || !(values[0] is float))
+            {
+                return new Quaternion();
+            }
+            return new Quaternion((float)values[0], (float)values[1], (float)values[2], (float)values[3]);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            Quaternion q = (Quaternion)value;
+            return new object[]{ q.X, q.Y, q.Z, q.W };
+        }
+    }
+}

--- a/FFTrainer/FFTrainer.csproj
+++ b/FFTrainer/FFTrainer.csproj
@@ -132,6 +132,7 @@
     </Compile>
     <Compile Include="Commands\DelegateCommand.cs" />
     <Compile Include="Commands\RefreshEntitiesCommand.cs" />
+    <Compile Include="Converters\QuaternionConverter.cs" />
     <Compile Include="Converters\EnumBooleanConverter.cs" />
     <Compile Include="Converters\EnumDescriptionTypeConverter.cs" />
     <Compile Include="Models\BaseModel.cs" />
@@ -158,6 +159,9 @@
     </Compile>
     <Compile Include="Views\CharacterDetailsView4.xaml.cs">
       <DependentUpon>CharacterDetailsView4.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\RotationView.xaml.cs">
+      <DependentUpon>RotationView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Windows\AccentStyleWindow.xaml.cs">
       <DependentUpon>AccentStyleWindow.xaml</DependentUpon>
@@ -321,6 +325,10 @@
     <Page Include="Views\CharacterDetailsView4.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\RotationView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\AccentStyleWindow.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/FFTrainer/Views/CharacterDetailsView3.xaml
+++ b/FFTrainer/Views/CharacterDetailsView3.xaml
@@ -4,8 +4,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls" 
+             xmlns:Views="clr-namespace:FFTrainer.Views"
+             xmlns:Converters="clr-namespace:FFTrainer.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="1075">
+    <UserControl.Resources>
+        <Converters:QuaternionConverter x:Key="QuaternionConverter" />
+    </UserControl.Resources>
     <Grid>
         <Border BorderBrush="Black" BorderThickness="3" HorizontalAlignment="Left" Height="182" Margin="10,36,0,0" VerticalAlignment="Top" Width="264"/>
         <Label Content="{DynamicResource SkinColor}" HorizontalAlignment="Left" Margin="92,5,0,0" VerticalAlignment="Top" Width="138" FontSize="16" FontWeight="Bold"/>
@@ -89,6 +94,18 @@
         <CheckBox IsChecked="{Binding Path=CharacterDetails.CharacterDetails.ScaleX.freeze}" Content="X" HorizontalAlignment="Left" Margin="850,66,0,0" VerticalAlignment="Top" FontWeight="Bold" Width="44"/>
         <CheckBox IsChecked="{Binding Path=CharacterDetails.CharacterDetails.ScaleY.freeze}" Content="Y" HorizontalAlignment="Left" Margin="850,93,0,0" VerticalAlignment="Top" FontWeight="Bold" Width="44"/>
         <CheckBox IsChecked="{Binding Path=CharacterDetails.CharacterDetails.ScaleZ.freeze}" Content="Z" HorizontalAlignment="Left" Margin="850,121,0,0" VerticalAlignment="Top" FontWeight="Bold" Width="44"/>
-
+        <Label Content="{DynamicResource Rotation}" HorizontalAlignment="Left" Margin="902,152,0,0" VerticalAlignment="Top" Width="81" FontSize="16" FontWeight="Bold"/>
+        <Border BorderBrush="Black" BorderThickness="3" HorizontalAlignment="Left" Height="200" Margin="840,188,0,0" VerticalAlignment="Top" Width="200" Background="#FF2E2E2E">
+            <Views:RotationView Height="Auto" Width="Auto">
+                <Views:RotationView.DataContext>
+                    <MultiBinding Converter="{StaticResource ResourceKey=QuaternionConverter}">
+                        <Binding Path="CharacterDetails.CharacterDetails.Rotation.value" NotifyOnSourceUpdated="True" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" />
+                        <Binding Path="CharacterDetails.CharacterDetails.Rotation2.value" NotifyOnSourceUpdated="True" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" />
+                        <Binding Path="CharacterDetails.CharacterDetails.Rotation3.value" NotifyOnSourceUpdated="True" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" />
+                        <Binding Path="CharacterDetails.CharacterDetails.Rotation4.value" NotifyOnSourceUpdated="True" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" />
+                    </MultiBinding>
+                </Views:RotationView.DataContext>
+            </Views:RotationView>
+        </Border>
     </Grid>
 </UserControl>

--- a/FFTrainer/Views/RotationView.xaml
+++ b/FFTrainer/Views/RotationView.xaml
@@ -1,0 +1,234 @@
+<UserControl x:Class="FFTrainer.Views.RotationView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:FFTrainer.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="200" d:DesignWidth="200">
+    <Grid>
+        <Viewport3D VerticalAlignment="Top" Height="200" MouseMove="Viewport3D_MouseMove" MouseDown="Viewport3D_MouseDown" MouseUp="Viewport3D_MouseUp">
+            <Viewport3D.Camera>
+                <PerspectiveCamera x:Name="rotationCamera" Position="1.5,1.5,1.5" LookDirection="-4,-3,-4" FieldOfView="60" />
+            </Viewport3D.Camera>
+            <Viewport3D.Children>
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <DirectionalLight Color="#FFFFFF" Direction="-1,-1,-1" />
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <GeometryModel3D>
+                            <GeometryModel3D.Geometry>
+                                <MeshGeometry3D Positions="2,-0,2 -2,0,-2 -2,-0,2 2,-0,2 2,0,-2 -2,0,-2 "
+                                                    TriangleIndices="0 1 2 3 4 5 "
+                                                    TextureCoordinates="1,1 0,0 0,1 1,1 1,0 0,0 "
+                                                    Normals="0,0,1 0,0,1 0,0,1 0,0,1 0,0,1 0,0,1 " />
+                            </GeometryModel3D.Geometry>
+                            <GeometryModel3D.Material>
+                                <DiffuseMaterial>
+                                    <DiffuseMaterial.Brush>
+                                        <DrawingBrush Viewport="0,0,0.1,0.1" TileMode="Tile">
+                                            <DrawingBrush.Drawing>
+                                                <DrawingGroup>
+                                                    <GeometryDrawing Geometry="M0,0.1 L 0,0 0.1,0 0.1,0.01 0.01,0.01 0.01,0.1Z" Brush="#FF666666"/>
+                                                </DrawingGroup>
+                                            </DrawingBrush.Drawing>
+                                        </DrawingBrush>
+                                    </DiffuseMaterial.Brush>
+                                </DiffuseMaterial>
+                            </GeometryModel3D.Material>
+                        </GeometryModel3D>
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <Model3DGroup>
+                            <!-- Bottom Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="0.5,0,0.5 -0.5,0,-0.5 0.5,0,-0.5 0.5,0,0.5 -0.5,0,0.5 -0.5,0,-0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="1,1 0,0 0,1 1,1 1,0 0,0 "
+                                                        Normals="0,-1,0 0,-1,0 0,-1,0 0,-1,0 0,-1,0 0,-1,0 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Lime" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White">D</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+
+                            <!-- Left Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="0.5,1,0.5 0.5,0,-0.5 0.5,1,-0.5 0.5,1,0.5 0.5,0,0.5 0.5,0,-0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="0,0 1,1 1,0 0,0 0,1 1,1 "
+                                                        Normals="1,0,0 1,0,0 1,0,0 1,0,0 1,0,0 1,0,0 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Blue" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White" RenderTransformOrigin="0.5,0.5">L</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+
+                            <!-- Front Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="-0.5,1,0.5 0.5,0,0.5 0.5,1,0.5 -0.5,1,0.5 -0.5,0,0.5 0.5,0,0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="0,0 1,1 1,0 0,0 0,1 1,1 "
+                                                        Normals="0,0,1 0,0,1 0,0,1 0,0,1 0,0,1 0,0,1 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Red" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White">F</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+
+                            <!-- Right Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="-0.5,0,0.5 -0.5,1,-0.5 -0.5,0,-0.5 -0.5,0,0.5 -0.5,1,0.5 -0.5,1,-0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="1,1 0,0 0,1 1,1 1,0 0,0 "
+                                                        Normals="-1,0,0 -1,0,0 -1,0,0 -1,0,0 -1,0,0 -1,0,0 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Blue" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White">R</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+
+                            <!-- Back Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="0.5,1,-0.5 -0.5,0,-0.5 -0.5,1,-0.5 0.5,1,-0.5 0.5,0,-0.5 -0.5,0,-0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="0,0 1,1 1,0 0,0 0,1 1,1 "
+                                                        Normals="0,0,-1 0,0,-1 0,0,-1 0,0,-1 0,0,-1 0,0,-1 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Red" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White">B</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+
+                            <!-- Top Face -->
+                            <GeometryModel3D>
+                                <GeometryModel3D.Geometry>
+                                    <MeshGeometry3D Positions="-0.5,1,0.5 0.5,1,-0.5 -0.5,1,-0.5 -0.5,1,0.5 0.5,1,0.5 0.5,1,-0.5 "
+                                                        TriangleIndices="0 1 2 3 4 5 "
+                                                        TextureCoordinates="1,1 0,0 0,1 1,1 1,0 0,0 "
+                                                        Normals="0,1,0 0,1,0 0,1,0 0,1,0 0,1,0 0,1,0 "
+                                                        />
+                                </GeometryModel3D.Geometry>
+                                <GeometryModel3D.Material>
+                                    <MaterialGroup>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <SolidColorBrush Color="Lime" Opacity="0.7"/>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                        <DiffuseMaterial>
+                                            <DiffuseMaterial.Brush>
+                                                <VisualBrush Viewport="0.2,0.2,0.6,0.6">
+                                                    <VisualBrush.Visual>
+                                                        <TextBlock Foreground="White">U</TextBlock>
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </DiffuseMaterial.Brush>
+                                        </DiffuseMaterial>
+                                    </MaterialGroup>
+                                </GeometryModel3D.Material>
+                            </GeometryModel3D>
+                            <Model3DGroup.Transform>
+                                <RotateTransform3D CenterY="0.5">
+                                    <RotateTransform3D.Rotation>
+                                        <QuaternionRotation3D x:Name="RotationQuaternion" Quaternion="{Binding}" />
+                                    </RotateTransform3D.Rotation>
+                                </RotateTransform3D>
+                            </Model3DGroup.Transform>
+                        </Model3DGroup>
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
+            </Viewport3D.Children>
+        </Viewport3D>
+    </Grid>
+</UserControl>

--- a/FFTrainer/Views/RotationView.xaml.cs
+++ b/FFTrainer/Views/RotationView.xaml.cs
@@ -1,0 +1,100 @@
+using FFTrainer.Models;
+using FFTrainer.Util;
+using FFTrainer.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media.Media3D;
+
+namespace FFTrainer.Views
+{
+    /// <summary>
+    /// Interaction logic for RotationView.xaml
+    /// </summary>
+    public partial class RotationView : UserControl
+    {
+        struct DragState
+        {
+            public Point lastPoint;
+            public bool isTracking;
+            public MouseButton mouseButton;
+        }
+
+        private DragState dragState;
+
+        public RotationView()
+        {
+            InitializeComponent();
+        }
+        private void Viewport3D_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            var el = (UIElement)sender;
+
+            if (el.IsMouseCaptured)
+            {
+                var curPoint = e.MouseDevice.GetPosition(el);
+
+                var delta = dragState.lastPoint - curPoint;
+                var angle = Vector3D.DotProduct(new Vector3D(delta.X, -delta.Y, 0), new Vector3D(1, 1, 0));
+
+                // Dragging the Left Mouse Button changes the pitch (facing up or down)
+                // Dragging the Middle Mouse Button changes the yaw (facing left or right)
+                // Dragging the Right Mouse Button changes the roll (leaning left or right)
+                Vector3D axis;
+                switch (dragState.mouseButton)
+                {
+                    case MouseButton.Left:
+                        axis = new Vector3D(1, 0, 0);
+                        break;
+                    case MouseButton.Middle:
+                        axis = new Vector3D(0, 1, 0);
+                        angle = -angle;
+                        break;
+                    case MouseButton.Right:
+                        axis = new Vector3D(0, 0, 1);
+                        angle = -angle;
+                        break;
+                    default:
+                        return;
+                }
+
+                // Applies the desired rotation first then the original rotation second.
+                // Not the other way around (which would be rotationDelta * q). This makes it
+                // more intuitive to adjust the roll, pitch, and yaw relative to the original
+                // rotation.
+                var rotationDelta = new Quaternion(axis, angle);
+                var q = RotationQuaternion.Quaternion * rotationDelta;
+                RotationQuaternion.SetCurrentValue(QuaternionRotation3D.QuaternionProperty, q);
+                dragState.lastPoint = curPoint;
+            }
+        }
+
+        private void Viewport3D_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            var el = (UIElement)sender;
+            if (dragState.isTracking)
+                return;
+
+            dragState.lastPoint = e.MouseDevice.GetPosition(el);
+            dragState.isTracking = true;
+            dragState.mouseButton = e.ChangedButton;
+            el.CaptureMouse();
+        }
+
+        private void Viewport3D_MouseUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            var el = (UIElement)sender;
+            el.ReleaseMouseCapture();
+
+            dragState.isTracking = false;
+
+            var qv = RotationQuaternion.GetValue(QuaternionRotation3D.QuaternionProperty);
+            var q = (Quaternion)qv;
+
+            MemoryManager.Instance.MemLib.writeMemory(MemoryManager.GetAddressString(CharacterDetailsViewModel.baseAddr, Settings.Instance.Character.Body.Base, Settings.Instance.Character.Body.Position.Rotation), "float", ((float)q.X).ToString());
+            MemoryManager.Instance.MemLib.writeMemory(MemoryManager.GetAddressString(CharacterDetailsViewModel.baseAddr, Settings.Instance.Character.Body.Base, Settings.Instance.Character.Body.Position.Rotation2), "float", ((float)q.Y).ToString());
+            MemoryManager.Instance.MemLib.writeMemory(MemoryManager.GetAddressString(CharacterDetailsViewModel.baseAddr, Settings.Instance.Character.Body.Base, Settings.Instance.Character.Body.Position.Rotation3), "float", ((float)q.Z).ToString());
+            MemoryManager.Instance.MemLib.writeMemory(MemoryManager.GetAddressString(CharacterDetailsViewModel.baseAddr, Settings.Instance.Character.Body.Base, Settings.Instance.Character.Body.Position.Rotation4), "float", ((float)q.W).ToString());
+        }
+    }
+}


### PR DESCRIPTION
To follow up after my suggestion in Discord (and disappearing for a while), I spent a little time with somewhat of a proof of concept of what a better user interface for rotations
would look like. It's not perfect and could use a lot of improvements, but it's a lot better than manipulating quaternions directly.

- Does not add any new dependencies
- Internally uses quaternions with the XYZW convention throughout
- Dragging over the control with different mouse buttons allows
  changing different rotations (pitch, yaw, roll) relative to the
  original yaw rotation. That means being able to being able to pitch
  your character to face the sky in one rotation rather than dealing
  with multiple rotations.
- Releasing the mouse after dragging sets the rotation value in-game.
- You can drag from left to right or from bottom to up or (left,bottom)
  to (right, up) to adjust any rotation. (left, up) to (right, bottom) drag
  isn't very effective since the positive X-motion cancels out the negative
  Y-motion.
- Placement of this control was kind of arbitrary. Might need some rearranging
  later on.

